### PR TITLE
Ensure options object exists for initialize

### DIFF
--- a/src/StackNavigator.js
+++ b/src/StackNavigator.js
@@ -381,6 +381,8 @@ define(['effects/SlideEffect'], function (SlideEffect) {
              * @constructs
              * */
             initialize:function (options) {
+                options || (options = {});
+                
                 // Setting default styles
                 this.$el.css({overflow:'hidden'});
 


### PR DESCRIPTION
If the StackNavigator is instantiated without an options object, a JavaScript error occurs in the initialize function when trying to access the popTransition.
