### PR TITLE
Require-Backbone projects fix.

### DIFF
--- a/backstack.js
+++ b/backstack.js
@@ -22,7 +22,7 @@
     // Set up BackStack appropriately for the environment.
     if (typeof define === 'function' && define.amd) {
         // AMD
-        define(['jquery', 'underscore', 'Backbone'], factory);
+        define(['jquery', 'underscore', 'backbone'], factory);
     } else {
         // Browser globals
         root.BackStack = factory((root.jQuery || root.Zepto || root.ender), root._, root.Backbone);


### PR DESCRIPTION
Almost all require+backbone projects configured that backbone named in lower case in config shim. So this change fix working of backstack on main part of backbone projects. For example look on backbone+require todo mvc. Wiothout this changes app fails after including backstack because require try load Backbone with Upper case from root of website.
